### PR TITLE
Don't petrify if affected by blindness

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
@@ -71,8 +71,9 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 	}
 	
 	public static boolean isBlindfolded(EntityLivingBase attackTarget) {
-		return attackTarget != null && attackTarget.getItemStackFromSlot(EntityEquipmentSlot.HEAD)
-				.getItem() == IafItemRegistry.blindfold;
+		return attackTarget != null && (attackTarget.getItemStackFromSlot(EntityEquipmentSlot.HEAD)
+				.getItem() == IafItemRegistry.blindfold
+				|| attackTarget.isPotionActive(Effects.BLINDNESS));
 	}
 	
 	@Nullable


### PR DESCRIPTION
This allows clever players to drink blindness potions or induce blindness some other way, such as literally having no eyes in Cyberware.  I've copied the change from 1.16 however so I'm unsure if the syntax is correct.